### PR TITLE
Jest Test Global Setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
       "gen-sche ma-types": "gql2ts src/schema.graphql -o src/types/schema.d.ts"
    },
    "jest": {
+       "globalSetup": "./src/test/initSetup.js",
       "transform": {
          "^.+\\.tsx?$": "ts-jest"
       },

--- a/src/modules/register/register.test.ts
+++ b/src/modules/register/register.test.ts
@@ -1,15 +1,6 @@
 import { request } from 'graphql-request';
 import { User } from '../../entity/User';
-import { startServer } from '../../startServer';
 import { duplicateEmail, emailTooShort, invalidEmail, invalidPassword } from './errorMessages';
-
-let getHost = () => '';
-
-beforeAll(async () => {
-    const app = await startServer();
-    const { port } = app.address();
-    getHost = () => `http://127.0.0.1:${port}`;
-})
 
 const email = 'fortune@fortune.com';
 const password = 'pass123';
@@ -25,7 +16,7 @@ const mutation = (e: string, p: string) => `
 
 describe('Register user', async() => {
     it('Ensures a user is registered', async() => {
-        const response = await request(getHost(), mutation(email, password));
+        const response = await request(process.env.TEST_HOST as string, mutation(email, password));
         expect(response).toEqual({ register: null });
         const users = await User.find({ where: { email }});
         expect(users).toHaveLength(1);
@@ -35,7 +26,7 @@ describe('Register user', async() => {
     })
 
     it('Ensures duplicate emails should fail', async() => {
-        const response2: any = await request(getHost(), mutation(email, password));
+        const response2: any = await request(process.env.TEST_HOST as string, mutation(email, password));
         expect(response2.register).toHaveLength(1);
         expect(response2.register[0]).toEqual({
             path: 'email',
@@ -44,7 +35,7 @@ describe('Register user', async() => {
     })
 
     it('Ensures invalid or short emails should fail', async() => {
-        const response3: any = await request(getHost(), mutation("f", password));
+        const response3: any = await request(process.env.TEST_HOST as string, mutation("f", password));
         expect(response3).toEqual({
             register: [
                 {
@@ -60,7 +51,7 @@ describe('Register user', async() => {
     })
 
     it('Ensures invalid password should fail', async() => {
-        const response4: any = await request(getHost(), mutation(email, "fo"));
+        const response4: any = await request(process.env.TEST_HOST as string, mutation(email, "fo"));
         expect(response4).toEqual({
             register: [
                 {
@@ -72,7 +63,7 @@ describe('Register user', async() => {
     })
 
     it('Ensures short and invalid email with invalid password should fail', async() => {
-        const response5: any = await request(getHost(), mutation("f", "fo"));
+        const response5: any = await request(process.env.TEST_HOST as string, mutation("f", "fo"));
         expect(response5).toEqual({
             register: [
                 {

--- a/src/modules/register/register.test.ts
+++ b/src/modules/register/register.test.ts
@@ -1,6 +1,7 @@
 import { request } from 'graphql-request';
 import { User } from '../../entity/User';
 import { duplicateEmail, emailTooShort, invalidEmail, invalidPassword } from './errorMessages';
+import { createTypeormConn } from '../../utils/createTypeormConn';
 
 const email = 'fortune@fortune.com';
 const password = 'pass123';
@@ -13,6 +14,10 @@ const mutation = (e: string, p: string) => `
         }
     }
 `;
+
+beforeAll(async() => {  
+    await createTypeormConn();
+})
 
 describe('Register user', async() => {
     it('Ensures a user is registered', async() => {

--- a/src/modules/register/resolvers.ts
+++ b/src/modules/register/resolvers.ts
@@ -46,7 +46,7 @@ export const resolvers: ResolverMap = {
 
             await user.save();
 
-            const link = await createConfirmEmailLink(url, user.id, redis);
+            await createConfirmEmailLink(url, user.id, redis);
             return null;
         },
     }

--- a/src/test/initSetup.js
+++ b/src/test/initSetup.js
@@ -1,0 +1,7 @@
+require("ts-node/register");
+const { setup } = require('./setup');
+
+module.exports = async function () {
+    await setup();
+    return null;
+};

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,7 @@
+import { startServer } from "../startServer";
+
+export const setup = async () => {
+    const app = await startServer();
+    const { port } = app.address() as any;
+    process.env.TEST_HOST = `http://127.0.0.1:${port}`;
+}


### PR DESCRIPTION
### Summary
This PR
- Adds a global setup for jest tests
- Move starting server from register tests to test setup